### PR TITLE
Add the Windows File I/O plugin example

### DIFF
--- a/corehook-plugins.sln
+++ b/corehook-plugins.sln
@@ -7,7 +7,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HideProcess", "src\Windows\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SpeedHack", "src\Windows\SpeedHack\SpeedHack.csproj", "{C4078A9E-D7A5-45AE-96D9-D7582E0302B3}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SocketHook", "src\Windows\SocketHook\SocketHook.csproj", "{5290068B-9BD0-4DF7-B5F9-8821FE617B24}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SocketHook", "src\Windows\SocketHook\SocketHook.csproj", "{5290068B-9BD0-4DF7-B5F9-8821FE617B24}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FileIO", "src\Windows\FileIO\FileIO.csproj", "{359E55C1-9CF8-47A8-9DC5-3B33028864BF}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -27,6 +29,10 @@ Global
 		{5290068B-9BD0-4DF7-B5F9-8821FE617B24}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5290068B-9BD0-4DF7-B5F9-8821FE617B24}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5290068B-9BD0-4DF7-B5F9-8821FE617B24}.Release|Any CPU.Build.0 = Release|Any CPU
+		{359E55C1-9CF8-47A8-9DC5-3B33028864BF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{359E55C1-9CF8-47A8-9DC5-3B33028864BF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{359E55C1-9CF8-47A8-9DC5-3B33028864BF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{359E55C1-9CF8-47A8-9DC5-3B33028864BF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Common/src/Interop/Windows/kernel32/Interop.GetFinalPathNameByHandle.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.GetFinalPathNameByHandle.cs
@@ -1,16 +1,16 @@
 using System;
 using System.Runtime.InteropServices;
+using System.Text;
 
 internal partial class Interop
 {
     internal partial class Kernel32
     {
         [DllImport(Libraries.Kernel32, SetLastError = true)]
-        internal static extern int ReadFile(
-            IntPtr handle,
-            IntPtr bytes,
-            int numBytesToRead,
-            out int numBytesRead,
-            IntPtr mustBeZero);
+        internal static extern uint GetFinalPathNameByHandle(
+            IntPtr file,
+            [Out] char[] filePath,
+            uint filePathSize,
+            uint flags);
     }
 }

--- a/src/Common/src/Interop/Windows/kernel32/Interop.ReadFile_IntPtr.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.ReadFile_IntPtr.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class Kernel32
+    {
+        [DllImport(Libraries.Kernel32, SetLastError = true)]
+        internal static extern int ReadFile(
+            IntPtr handle,
+            byte[] bytes,
+            int numBytesToRead,
+            out int numBytesRead,
+            IntPtr mustBeZero);
+    }
+}

--- a/src/Common/src/Interop/Windows/kernel32/Interop.WriteFile_IntPtr.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.WriteFile_IntPtr.cs
@@ -8,9 +8,9 @@ internal partial class Interop
         [DllImport(Libraries.Kernel32, SetLastError = true)]
         internal static extern int WriteFile(
             IntPtr handle,
-            byte[] bytes,
+            IntPtr bytes,
             int numBytesToWrite,
             out int numBytesWritten,
-            IntPtr mustBeZero);
+            IntPtr overlapped);
     }
 }

--- a/src/Common/src/Interop/Windows/kernel32/Interop.WriteFile_IntPtr.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.WriteFile_IntPtr.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class Kernel32
+    {
+        [DllImport(Libraries.Kernel32, SetLastError = true)]
+        internal static extern int WriteFile(
+            IntPtr handle,
+            byte[] bytes,
+            int numBytesToWrite,
+            out int numBytesWritten,
+            IntPtr mustBeZero);
+    }
+}

--- a/src/Windows/FileIO/FileIO.cs
+++ b/src/Windows/FileIO/FileIO.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using CoreHook;
+
+namespace FileIO
+{
+    public class FileIO : IEntryPoint
+    {
+        public FileIO(IContext context) { }
+        
+        public void Run(IContext contex)
+        {
+
+        }
+
+        private int Detour_WriteFile(IntPtr handle,
+            byte[] bytes,
+            int numBytesToWrite,
+            out int numBytesWritten,
+            IntPtr mustBeZero)
+        {
+            return Interop.Kernel32.WriteFile(handle, bytes, numBytesToWrite, out numBytesWritten, mustBeZero);
+        }
+    }
+}

--- a/src/Windows/FileIO/FileIO.cs
+++ b/src/Windows/FileIO/FileIO.cs
@@ -104,14 +104,7 @@ namespace FileIO
                 uint filePathLength = Interop.Kernel32.GetFinalPathNameByHandle(handle, filePath, This.MaxPathLength, 0);
 
                 // Check file name and increment the access count if valid
-                var fileName = new string(filePath, 0, (int)filePathLength);
-                if (!string.IsNullOrWhiteSpace(fileName))
-                {
-                    lock (This.FileList)
-                    {
-                        This.FileList[fileName] = This.FileList.ContainsKey(fileName) ? This.FileList[fileName] + 1 : 1;
-                    }
-                }
+                IncrementFileAccessCount(This.FileList, new string(filePath, 0, (int)filePathLength));
             }
             return Interop.Kernel32.ReadFile(handle, bytes, numBytesToRead, out numBytesRead, mustBeZero);
         }
@@ -130,16 +123,25 @@ namespace FileIO
                 uint filePathLength = Interop.Kernel32.GetFinalPathNameByHandle(handle, filePath, This.MaxPathLength, 0);
 
                 // Check file name and increment the access count if valid
-                var fileName = new string(filePath, 0, (int)filePathLength);
-                if (!string.IsNullOrWhiteSpace(fileName))
-                {
-                    lock (This.FileList)
-                    {
-                        This.FileList[fileName] = This.FileList.ContainsKey(fileName) ? This.FileList[fileName] + 1 : 1;
-                    }
-                }
+                IncrementFileAccessCount(This.FileList, new string(filePath, 0, (int)filePathLength));
             }
             return Interop.Kernel32.WriteFile(handle, bytes, numBytesToWrite, out numBytesWritten, overlapped);
+        }
+
+        /// <summary>
+        /// Increase the number of times a file was accessed from an I/O function.
+        /// </summary>
+        /// <param name="fileList">The list of files and their current access count.</param>
+        /// <param name="fileName">The name of the file being accessed.</param>
+        private void IncrementFileAccessCount(Dictionary<string, int> fileList, string fileName)
+        {
+            if (!string.IsNullOrWhiteSpace(fileName))
+            {
+                lock (fileList)
+                {
+                    fileList[fileName] = fileList.ContainsKey(fileName) ? fileList[fileName] + 1 : 1;
+                }
+            }
         }
     }
 }

--- a/src/Windows/FileIO/FileIO.cs
+++ b/src/Windows/FileIO/FileIO.cs
@@ -12,6 +12,16 @@ namespace FileIO
 
         }
 
+        private int Detour_ReadFile(
+            IntPtr handle,
+            byte[] bytes,
+            int numBytesToRead,
+            out int numBytesRead,
+            IntPtr mustBeZero)
+        {
+            return Interop.Kernel32.ReadFile(handle, bytes, numBytesToRead, out numBytesRead, mustBeZero);
+        }
+
         private int Detour_WriteFile(IntPtr handle,
             byte[] bytes,
             int numBytesToWrite,

--- a/src/Windows/FileIO/FileIO.cs
+++ b/src/Windows/FileIO/FileIO.cs
@@ -1,34 +1,131 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
 using CoreHook;
 
 namespace FileIO
 {
     public class FileIO : IEntryPoint
     {
+        /// <summary>
+        /// List of files that have been read or written to, with a counter to keep track of the number of accesses.
+        /// </summary>
+        private Dictionary<string, int> FileList = new Dictionary<string, int>();
+
+        /// <summary>
+        ///  The max length of a file path on Windows.
+        /// </summary>
+        public uint MaxPathLength = 260;
+
+        IHook ReadFileHook;
+        IHook WriteFileHook;
+
+        [UnmanagedFunctionPointer(CallingConvention.StdCall, CharSet = CharSet.Unicode, SetLastError = true)]
+        internal delegate int ReadFileDelegate(IntPtr handle,
+            IntPtr bytes,
+            int numBytesToRead,
+            out int numBytesRead,
+            IntPtr mustBeZero);
+
+        [UnmanagedFunctionPointer(CallingConvention.StdCall, CharSet = CharSet.Unicode, SetLastError = true)]
+        internal delegate int WriteFileDelegate(IntPtr handle,
+            IntPtr bytes,
+            int numBytesToWrite,
+            out int numBytesWritten,
+            IntPtr overlapped);
+
         public FileIO(IContext context) { }
-        
+
         public void Run(IContext contex)
         {
+            ReadFileHook = HookFactory.CreateHook<ReadFileDelegate>(LocalHook.GetProcAddress(Interop.Libraries.Kernel32, "ReadFile"), Detour_ReadFile, this);
+            WriteFileHook = HookFactory.CreateHook<WriteFileDelegate>(LocalHook.GetProcAddress(Interop.Libraries.Kernel32, "WriteFile"), Detour_WriteFile, this);
 
+            DisplayFileAccess().GetAwaiter().GetResult();
+        }
+
+        private async Task DisplayFileAccess()
+        {
+            // Ensure we are running in a new thread
+            await Task.Yield();
+
+            // Enable detours for all threads except the current thread
+            ReadFileHook.ThreadACL.SetExclusiveACL(new int[] { 0 });
+            WriteFileHook.ThreadACL.SetExclusiveACL(new int[] { 0 });
+
+            try
+            {
+                while (true)
+                {
+                    Thread.Sleep(500);
+                    lock (FileList)
+                    {
+                        if (FileList.Count > 0)
+                        {
+                            foreach (var file in FileList)
+                            {
+                                Console.WriteLine($"{file.Key} was accesssed {file.Value} time(s).");
+                            }
+                        }
+                    }
+                }
+            }
+            catch
+            {
+
+            }
         }
 
         private int Detour_ReadFile(
             IntPtr handle,
-            byte[] bytes,
+            IntPtr bytes,
             int numBytesToRead,
             out int numBytesRead,
             IntPtr mustBeZero)
         {
+            FileIO This = (FileIO)HookRuntimeInfo.Callback;
+            if (This != null)
+            {
+                // Get the file name from the handle and increment the access count
+                char[] filePath = new char[This.MaxPathLength];
+                uint filePathLength = Interop.Kernel32.GetFinalPathNameByHandle(handle, filePath, This.MaxPathLength, 0);
+
+                var fileName = new string(filePath, 0, (int)filePathLength);
+                if (!string.IsNullOrWhiteSpace(fileName))
+                {
+                    lock (This.FileList)
+                    {
+                        This.FileList[fileName] = This.FileList.ContainsKey(fileName) ? This.FileList[fileName] + 1 : 1;
+                    }
+                }
+            }
             return Interop.Kernel32.ReadFile(handle, bytes, numBytesToRead, out numBytesRead, mustBeZero);
         }
 
         private int Detour_WriteFile(IntPtr handle,
-            byte[] bytes,
+            IntPtr bytes,
             int numBytesToWrite,
             out int numBytesWritten,
-            IntPtr mustBeZero)
+            IntPtr overlapped)
         {
-            return Interop.Kernel32.WriteFile(handle, bytes, numBytesToWrite, out numBytesWritten, mustBeZero);
+            FileIO This = (FileIO)HookRuntimeInfo.Callback;
+            if (This != null)
+            {
+                // Get the file name from the handle and increment the access count
+                char[] filePath = new char[This.MaxPathLength];
+                uint filePathLength = Interop.Kernel32.GetFinalPathNameByHandle(handle, filePath, This.MaxPathLength, 0);
+                var fileName = new string(filePath, 0, (int)filePathLength);
+                if (!string.IsNullOrWhiteSpace(fileName))
+                {
+                    lock (This.FileList)
+                    {
+                        This.FileList[fileName] = This.FileList.ContainsKey(fileName) ? This.FileList[fileName] + 1 : 1;
+                    }
+                }
+            }
+            return Interop.Kernel32.WriteFile(handle, bytes, numBytesToWrite, out numBytesWritten, overlapped);
         }
     }
 }

--- a/src/Windows/FileIO/FileIO.csproj
+++ b/src/Windows/FileIO/FileIO.csproj
@@ -17,5 +17,8 @@
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.WriteFile_IntPtr.cs">
       <Link>Common\Interop\Windows\kernel32\Interop.WriteFile_IntPtr.cs</Link>
     </Compile>
+       <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.GetFinalPathNameByHandle.cs">
+      <Link>Common\Interop\Windows\kernel32\Interop.GetFinalPathNameByHandle.cs</Link>
+    </Compile> 
   </ItemGroup>    
 </Project>

--- a/src/Windows/FileIO/FileIO.csproj
+++ b/src/Windows/FileIO/FileIO.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CoreHook" Version="1.0.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+      <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.WriteFile_IntPtr.cs">
+      <Link>Common\Interop\Windows\kernel32\Interop.WriteFile_IntPtr.cs</Link>
+    </Compile>
+  </ItemGroup>    
+</Project>

--- a/src/Windows/FileIO/FileIO.csproj
+++ b/src/Windows/FileIO/FileIO.csproj
@@ -11,6 +11,9 @@
     <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.ReadFile_IntPtr.cs">
+      <Link>Common\Interop\Windows\kernel32\Interop.ReadFile_IntPtr.cs</Link>
+    </Compile>    
     <Compile Include="$(CommonPath)\Interop\Windows\kernel32\Interop.WriteFile_IntPtr.cs">
       <Link>Common\Interop\Windows\kernel32\Interop.WriteFile_IntPtr.cs</Link>
     </Compile>


### PR DESCRIPTION
The example detours the ReadFile and WriteFile functions on Windows and increments a count in a directory for each access, which is then printed to the console.