### PR TITLE
Update examples to use latest version of the library

### DIFF
--- a/src/Windows/FileIO/FileIO.cs
+++ b/src/Windows/FileIO/FileIO.cs
@@ -28,14 +28,14 @@ namespace FileIO
         /// </summary>
         private IHook _writeFileHook;
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall, CharSet = CharSet.Unicode, SetLastError = true)]
+        [UnmanagedFunctionPointer(CallingConvention.StdCall, SetLastError = true)]
         internal delegate int ReadFileDelegate(IntPtr handle,
             IntPtr bytes,
             int numBytesToRead,
             out int numBytesRead,
             IntPtr mustBeZero);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall, CharSet = CharSet.Unicode, SetLastError = true)]
+        [UnmanagedFunctionPointer(CallingConvention.StdCall, SetLastError = true)]
         internal delegate int WriteFileDelegate(IntPtr handle,
             IntPtr bytes,
             int numBytesToWrite,

--- a/src/Windows/FileIO/FileIO.csproj
+++ b/src/Windows/FileIO/FileIO.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreHook" Version="1.0.2" />
+    <PackageReference Include="CoreHook" Version="1.0.4" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">

--- a/src/Windows/HideProcess/HideProcess.cs
+++ b/src/Windows/HideProcess/HideProcess.cs
@@ -9,7 +9,7 @@ namespace HideProcess
         // Process structures and GetProcessShortName code from:
         // https://github.com/dotnet/corefx/blob/master/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall, CharSet = CharSet.Unicode, SetLastError = true)]
+        [UnmanagedFunctionPointer(CallingConvention.StdCall, SetLastError = true)]
         internal delegate int NtQuerySystemInformationDelegate(int query, IntPtr dataPtr, int size, out int returnedSize);
 
         [StructLayout(LayoutKind.Sequential)]

--- a/src/Windows/HideProcess/HideProcess.csproj
+++ b/src/Windows/HideProcess/HideProcess.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreHook" Version="1.0.2" />
+    <PackageReference Include="CoreHook" Version="1.0.4" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">

--- a/src/Windows/SocketHook/SocketHook.cs
+++ b/src/Windows/SocketHook/SocketHook.cs
@@ -72,7 +72,7 @@ namespace SocketHook
             }
         }
         
-        [UnmanagedFunctionPointer(CallingConvention.StdCall, CharSet = CharSet.Unicode, SetLastError = true)]
+        [UnmanagedFunctionPointer(CallingConvention.StdCall, SetLastError = true)]
         private unsafe delegate SocketError WSASendDelegate(
             IntPtr socketHandle,
             WSABuffer* buffers,
@@ -100,7 +100,7 @@ namespace SocketHook
             return Interop.Winsock.WSASend(socketHandle, buffers, bufferCount, out bytesTransferred, socketFlags, overlapped, completionRoutine);
         }
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall, CharSet = CharSet.Unicode, SetLastError = true)]
+        [UnmanagedFunctionPointer(CallingConvention.StdCall, SetLastError = true)]
         private unsafe delegate SocketError WSARecvDelegate(
             IntPtr socketHandle,
             ref WSABuffer buffer,
@@ -123,6 +123,7 @@ namespace SocketHook
             return Interop.Winsock.WSARecv(socketHandle, &localBuffer, bufferCount, out bytesTransferred, ref socketFlags, overlapped, completionRoutine);
         }
 
+        [UnmanagedFunctionPointer(CallingConvention.StdCall, SetLastError = true)]
         internal unsafe delegate int RecvDelegate(
             [In] IntPtr socketHandle,
             [In] byte* pinnedBuffer,
@@ -138,6 +139,7 @@ namespace SocketHook
             return Interop.Winsock.recv(socketHandle, pinnedBuffer, len, socketFlags);
         }
 
+        [UnmanagedFunctionPointer(CallingConvention.StdCall, SetLastError = true)]
         internal unsafe delegate int SendDelegaqte(
             [In] IntPtr socketHandle,
             [In] byte* pinnedBuffer,
@@ -153,6 +155,7 @@ namespace SocketHook
             return Interop.Winsock.send(socketHandle, pinnedBuffer, len, socketFlags);
         }
 
+        [UnmanagedFunctionPointer(CallingConvention.StdCall, SetLastError = true)]
         internal unsafe delegate int RecvfromDelegate(
             [In] IntPtr socketHandle,
             [In] byte* pinnedBuffer,
@@ -172,6 +175,7 @@ namespace SocketHook
             return Interop.Winsock.recvfrom(socketHandle, pinnedBuffer, len, socketFlags, socketAddress, ref socketAddressSize);
         }
 
+        [UnmanagedFunctionPointer(CallingConvention.StdCall, SetLastError = true)]
         internal unsafe delegate int SendtoDelegate(
             [In] IntPtr socketHandle,
             [In] byte* pinnedBuffer,

--- a/src/Windows/SocketHook/SocketHook.csproj
+++ b/src/Windows/SocketHook/SocketHook.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreHook" Version="1.0.2" />
+    <PackageReference Include="CoreHook" Version="1.0.4" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">

--- a/src/Windows/SpeedHack/SpeedHack.cs
+++ b/src/Windows/SpeedHack/SpeedHack.cs
@@ -6,16 +6,16 @@ namespace SpeedHack
 {
     public class SpeedHack : IEntryPoint
     {
-        [UnmanagedFunctionPointer(CallingConvention.StdCall, CharSet = CharSet.Unicode, SetLastError = true)]
+        [UnmanagedFunctionPointer(CallingConvention.StdCall, SetLastError = true)]
         private delegate uint GetTickCountDelegate();
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall, CharSet = CharSet.Unicode, SetLastError = true)]
+        [UnmanagedFunctionPointer(CallingConvention.StdCall, SetLastError = true)]
         private delegate ulong GetTickCount64Delegate();
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall, CharSet = CharSet.Unicode, SetLastError = true)]
+        [UnmanagedFunctionPointer(CallingConvention.StdCall, SetLastError = true)]
         private delegate Interop.BOOL QueryPerformanceCounterDelegate(out long performanceCount);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall, CharSet = CharSet.Unicode, SetLastError = true)]
+        [UnmanagedFunctionPointer(CallingConvention.StdCall, SetLastError = true)]
         private delegate uint SleepExDelegate(uint milliSeconds, Interop.BOOL alertable);
 
         private IHook _getTickCount;

--- a/src/Windows/SpeedHack/SpeedHack.csproj
+++ b/src/Windows/SpeedHack/SpeedHack.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreHook" Version="1.0.2" />
+    <PackageReference Include="CoreHook" Version="1.0.4" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">


### PR DESCRIPTION
Update the examples to use version 1.0.4 since it is the latest available on NuGet.